### PR TITLE
Fixed minor error in menu_rooms condition

### DIFF
--- a/src/bomberman_mod.sma
+++ b/src/bomberman_mod.sma
@@ -952,7 +952,7 @@ public menu_rooms(id, menu, item)
 	if (!is_user_connected(id))
 		return PLUGIN_HANDLED;
 	
-	if (item == 8)
+	if (item >= 8)
 	{
 		show_menu_intro(id);
 		return PLUGIN_HANDLED;


### PR DESCRIPTION
Sometimes in the server console there are errors like this:

```
L 02/13/2022 - 20:09:41: [AMXX] Run time error 4: index out of bounds 
L 02/13/2022 - 20:09:41: [AMXX]    [0] bomberman_mod.sma::menu_rooms (line 1004)
```

I'm not sure what caused this error, but an extra check of the item in the room menu handler solved the problem.